### PR TITLE
feat. 구간별 해당 날짜 종가, 거래량 데이터 제공

### DIFF
--- a/ditto-module-batch/src/main/java/org/example/controller/ChartController.java
+++ b/ditto-module-batch/src/main/java/org/example/controller/ChartController.java
@@ -1,0 +1,32 @@
+package org.example.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.dto.ChartDto;
+import org.example.global.response.BaseResponse;
+import org.example.service.ChartService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/chart/{itemCode}")
+public class ChartController {
+    private final ChartService chartService;
+
+    @GetMapping("/month")
+    public BaseResponse<List<ChartDto>> drawMonthlyChart(@PathVariable("itemCode") String itemCode){
+        log.info(itemCode);
+        return new BaseResponse<>(chartService.drawMonthlyChart(itemCode));
+    }
+
+    @GetMapping("/year/{num}")
+    public BaseResponse<List<ChartDto>> drawYearlyChart(@PathVariable("itemCode") String itemCode, @PathVariable("num") int num){
+        return new BaseResponse<>(chartService.drawYearlyChart(itemCode, num));
+    }
+}

--- a/ditto-module-batch/src/main/java/org/example/dto/ChartDto.java
+++ b/ditto-module-batch/src/main/java/org/example/dto/ChartDto.java
@@ -1,0 +1,22 @@
+package org.example.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.domain.PricePerDay;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChartDto {
+    private Long companyId;
+    private LocalDate date;
+    private Integer lastPrice;
+    private Long tradingVolume;
+
+    public ChartDto(PricePerDay pricePerDay){
+        this(pricePerDay.getCompany().getId(), pricePerDay.getDate(), pricePerDay.getLastPrice(), pricePerDay.getTradingVolume());
+    }
+}

--- a/ditto-module-batch/src/main/java/org/example/repository/PricePerDayRepository.java
+++ b/ditto-module-batch/src/main/java/org/example/repository/PricePerDayRepository.java
@@ -3,5 +3,12 @@ package org.example.repository;
 import org.example.domain.PricePerDay;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PricePerDayRepository extends JpaRepository<PricePerDay, Long> {
+
+    List<PricePerDay> findTop25ByCompanyIdOrderByDateDesc(Long companyId);
+    List<PricePerDay> findTop300ByCompanyIdOrderByDateDesc(Long companyId);
+    List<PricePerDay> findTop900ByCompanyIdOrderByDateDesc(Long companyId);
+    List<PricePerDay> findTop1500ByCompanyIdOrderByDateDesc(Long companyId);
 }

--- a/ditto-module-batch/src/main/java/org/example/service/ChartService.java
+++ b/ditto-module-batch/src/main/java/org/example/service/ChartService.java
@@ -1,0 +1,50 @@
+package org.example.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.domain.Company;
+import org.example.domain.PricePerDay;
+import org.example.dto.ChartDto;
+import org.example.global.exception.NoSuchCompanyException;
+import org.example.repository.CompanyRepository;
+import org.example.repository.PricePerDayRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChartService {
+    private final CompanyRepository companyRepository;
+    private final PricePerDayRepository pricePerDayRepository;
+    public List<ChartDto> drawMonthlyChart(String itemCode) {
+        Company company = companyRepository.findByItemCode(itemCode).orElseThrow(() -> {
+            throw new NoSuchCompanyException();
+        });
+
+        List<PricePerDay> monthlyPriceList = pricePerDayRepository.findTop25ByCompanyIdOrderByDateDesc(company.getId());
+
+        return monthlyPriceList.stream().map(res -> new ChartDto(res)).collect(Collectors.toList());
+    }
+
+    public List<ChartDto> drawYearlyChart(String itemCode, int num) {
+        Company company = companyRepository.findByItemCode(itemCode).orElseThrow(() -> {
+            throw new NoSuchCompanyException();
+        });
+
+        List<PricePerDay> yearlyPriceList = null;
+
+        if (num == 1){
+            yearlyPriceList = pricePerDayRepository.findTop300ByCompanyIdOrderByDateDesc(company.getId());
+        } else if (num == 3) {
+            yearlyPriceList = pricePerDayRepository.findTop900ByCompanyIdOrderByDateDesc(company.getId());
+        } else if (num == 5) {
+            yearlyPriceList = pricePerDayRepository.findTop1500ByCompanyIdOrderByDateDesc(company.getId());
+        }
+
+
+        return yearlyPriceList.stream().map(res -> new ChartDto(res)).collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## 작업 내용
- 1개월, 1년, 3년, 5년에 해당하는 날짜별 종가, 거래량 데이터를 제공하는 API 생성
## 스크린샷

## 주의사항

Closes #42 
